### PR TITLE
`to_dict` method 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ deploy:
   on:
     distributions: sdist bdist_wheel
     repo: CrossNox/YouConfigMe
+    branch: master
+  skip_existing: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_files = LICENSE

--- a/tests/test_config_from_ini_file.py
+++ b/tests/test_config_from_ini_file.py
@@ -25,6 +25,21 @@ k4=4
     return Config(from_items=tf.name)
 
 
+def test_config_from_tempfile_sa_to_dict(config_from_tempfile):
+    assert config_from_tempfile.a.to_dict() == {'k1': '1', 'k2': '2'}
+
+
+def test_config_from_tempfile_sb_to_dict(config_from_tempfile):
+    assert config_from_tempfile.b.to_dict() == {'k3': '3', 'k4': '4'}
+
+
+def test_config_from_tempfile_to_dict(config_from_tempfile):
+    assert config_from_tempfile.to_dict() == {
+        'a': {'k1': '1', 'k2': '2'},
+        'b': {'k3': '3', 'k4': '4'},
+    }
+
+
 def test_config_from_tempfile_sa_k1(config_from_tempfile):
     assert config_from_tempfile.a.k1() == '1'
     assert config_from_tempfile.a.k1(cast=int) == 1

--- a/tests/test_config_from_ini_file_with_default_section.py
+++ b/tests/test_config_from_ini_file_with_default_section.py
@@ -26,6 +26,23 @@ k4=4
     return Config(from_items=tf.name, default_section='b')
 
 
+def test_config_from_tempfile_defs_sa_to_dict(config_from_tempfile_defs):
+    assert config_from_tempfile_defs.a.to_dict() == {'k1': '1', 'k2': '2'}
+
+
+def test_config_from_tempfile_defs_sb_to_dict(config_from_tempfile_defs):
+    with pytest.raises(ConfigItemNotFound):
+        config_from_tempfile_defs.b.to_dict()
+
+
+def test_config_from_tempfile_defs_to_dict(config_from_tempfile_defs):
+    assert config_from_tempfile_defs.to_dict() == {
+        'a': {'k1': '1', 'k2': '2'},
+        'k3': '3',
+        'k4': '4',
+    }
+
+
 def test_config_from_tempfile_defs_sa_k1(config_from_tempfile_defs):
     assert config_from_tempfile_defs.a.k1() == '1'
     assert config_from_tempfile_defs.a.k1(cast=int) == 1

--- a/tests/test_config_from_mapping.py
+++ b/tests/test_config_from_mapping.py
@@ -12,6 +12,21 @@ def config_dict():
     return Config(from_items={'a': {'k1': 1, 'k2': 2}, 'b': {'k3': 3, 'k4': 4}})
 
 
+def test_config_from_mapping_sa_to_dict(config_dict):
+    assert config_dict.a.to_dict() == {'k1': '1', 'k2': '2'}
+
+
+def test_config_from_mapping_sb_to_dict(config_dict):
+    assert config_dict.b.to_dict() == {'k3': '3', 'k4': '4'}
+
+
+def test_config_from_mapping_to_dict(config_dict):
+    assert config_dict.to_dict() == {
+        'a': {'k1': '1', 'k2': '2'},
+        'b': {'k3': '3', 'k4': '4'},
+    }
+
+
 def test_config_from_mapping_sa_k1(config_dict):
     assert config_dict.a.k1() == '1'
     assert config_dict.a.k1(cast=int) == 1

--- a/tests/test_config_from_mapping_default_osenv.py
+++ b/tests/test_config_from_mapping_default_osenv.py
@@ -22,18 +22,19 @@ def config_dict_defs_osenv():
 
 
 def test_config_from_mapping_env_defs_sa_to_dict(config_dict_defs_osenv):
-    assert config_dict_defs_osenv.a.to_dict() == {'k1': '1', 'k2': '2', 'k7': '7'}
+    assert config_dict_defs_osenv.a.to_dict() == {'k1': '1', 'k2': '2'}
 
 
 def test_config_from_mapping_env_defs_sb_to_dict(config_dict_defs_osenv):
-    assert config_dict_defs_osenv.b.to_dict() == {'k3': '3', 'k4': '4'}
+    with pytest.raises(ConfigItemNotFound):
+        config_dict_defs_osenv.b.to_dict()
 
 
 def test_config_from_mapping_env_defs_to_dict(config_dict_defs_osenv):
     assert config_dict_defs_osenv.to_dict() == {
-        'a': {'k1': '1', 'k2': '2', 'k7': '7'},
-        'b': {'k3': '3', 'k4': '4'},
-        'k7': '11',
+        'a': {'k1': '1', 'k2': '2'},
+        'k3': '3',
+        'k4': '4',
     }
 
 

--- a/tests/test_config_from_mapping_default_osenv.py
+++ b/tests/test_config_from_mapping_default_osenv.py
@@ -21,6 +21,22 @@ def config_dict_defs_osenv():
     del os.environ['K7']
 
 
+def test_config_from_mapping_env_defs_sa_to_dict(config_dict_defs_osenv):
+    assert config_dict_defs_osenv.a.to_dict() == {'k1': '1', 'k2': '2', 'k7': '7'}
+
+
+def test_config_from_mapping_env_defs_sb_to_dict(config_dict_defs_osenv):
+    assert config_dict_defs_osenv.b.to_dict() == {'k3': '3', 'k4': '4'}
+
+
+def test_config_from_mapping_env_defs_to_dict(config_dict_defs_osenv):
+    assert config_dict_defs_osenv.to_dict() == {
+        'a': {'k1': '1', 'k2': '2', 'k7': '7'},
+        'b': {'k3': '3', 'k4': '4'},
+        'k7': '11',
+    }
+
+
 def test_config_from_mapping_env_defs_sa_k1(config_dict_defs_osenv):
     assert config_dict_defs_osenv.a.k1() == '1'
     assert config_dict_defs_osenv.a.k1(cast=int) == 1

--- a/tests/test_config_from_mapping_with_default_section.py
+++ b/tests/test_config_from_mapping_with_default_section.py
@@ -15,6 +15,23 @@ def config_dict_defs():
     )
 
 
+def test_config_from_mapping_defs_sa_to_dict(config_dict_defs):
+    assert config_dict_defs.a.to_dict() == {'k1': '1', 'k2': '2'}
+
+
+def test_config_from_mapping_defs_sb_to_dict(config_dict_defs):
+    with pytest.raises(ConfigItemNotFound):
+        config_dict_defs.b.to_dict()
+
+
+def test_config_from_mapping_defs_to_dict(config_dict_defs):
+    assert config_dict_defs.to_dict() == {
+        'a': {'k1': '1', 'k2': '2'},
+        'k3': '3',
+        'k4': '4',
+    }
+
+
 def test_config_from_mapping_defs_sa_k1(config_dict_defs):
     assert config_dict_defs.a.k1() == '1'
     assert config_dict_defs.a.k1(cast=int) == 1

--- a/tests/test_config_from_string.py
+++ b/tests/test_config_from_string.py
@@ -20,6 +20,21 @@ k4=4
     return Config(from_items=s)
 
 
+def test_config_from_str_sa_to_dict(config_from_str):
+    assert config_from_str.a.to_dict() == {'k1': '1', 'k2': '2'}
+
+
+def test_config_from_str_sb_to_dict(config_from_str):
+    assert config_from_str.b.to_dict() == {'k3': '3', 'k4': '4'}
+
+
+def test_config_from_str_to_dict(config_from_str):
+    assert config_from_str.to_dict() == {
+        'a': {'k1': '1', 'k2': '2'},
+        'b': {'k3': '3', 'k4': '4'},
+    }
+
+
 def test_config_from_str_sa_k1(config_from_str):
     assert config_from_str.a.k1() == '1'
     assert config_from_str.a.k1(cast=int) == 1

--- a/tests/test_config_from_string_with_default_section.py
+++ b/tests/test_config_from_string_with_default_section.py
@@ -20,6 +20,23 @@ k4=4
     return Config(from_items=s, default_section='b')
 
 
+def test_config_from_str_defs_sa_to_dict(config_from_str_defs):
+    assert config_from_str_defs.a.to_dict() == {'k1': '1', 'k2': '2'}
+
+
+def test_config_from_str_defs_sb_to_dict(config_from_str_defs):
+    with pytest.raises(ConfigItemNotFound):
+        config_from_str_defs.b.to_dict()
+
+
+def test_config_from_str_defs_to_dict(config_from_str_defs):
+    assert config_from_str_defs.to_dict() == {
+        'a': {'k1': '1', 'k2': '2'},
+        'k3': '3',
+        'k4': '4',
+    }
+
+
 def test_config_from_str_defs_sa_k1(config_from_str_defs):
     assert config_from_str_defs.a.k1() == '1'
     assert config_from_str_defs.a.k1(cast=int) == 1

--- a/tests/test_config_section.py
+++ b/tests/test_config_section.py
@@ -19,7 +19,7 @@ def config_section():
 
 
 def test_to_dict(config_section):
-    assert config_section.to_dict() == {'z': '0', 'DEBUSSY': '1'}
+    assert config_section.to_dict() == {'z': '0'}
 
 
 def test_val_ex(config_section):

--- a/tests/test_config_section.py
+++ b/tests/test_config_section.py
@@ -18,6 +18,10 @@ def config_section():
     del os.environ['config_section_z']
 
 
+def test_to_dict(config_section):
+    assert config_section.to_dict() == {'z': '0', 'DEBUSSY': '1'}
+
+
 def test_val_ex(config_section):
     assert config_section.z() == '0'
 

--- a/youconfigme/__init__.py
+++ b/youconfigme/__init__.py
@@ -1,5 +1,5 @@
 """Entrypoint to make relevant classes available at the top level"""
 from .youconfigme import AutoConfig, Config, ConfigItemNotFound, ConfigSection
 
-__version__ = '0.2.4'
+__version__ = '0.3.0'
 __all__ = ['AutoConfig', 'Config', 'ConfigItemNotFound', 'ConfigSection']

--- a/youconfigme/youconfigme.py
+++ b/youconfigme/youconfigme.py
@@ -1,4 +1,8 @@
-"""Main module for youconfigme"""
+"""Main module for youconfigme
+
+Basically a Config is made out of ConfigSections.
+ConfigSections and Configs have ConfigAttributes.
+"""
 
 import io
 import logging
@@ -114,6 +118,15 @@ class ConfigSection:
     def __call__(self, default=None, cast=None):
         return ConfigAttribute(self.name, None, None)(default=default, cast=cast)
 
+    def to_dict(self):
+        ret_dict = {k: self.__getattr__(k)() for k in self.items.keys()}
+        section_prefix = f"{self.name.upper()}_"
+        for env_var, env_val in os.environ.items():
+            if env_var.startswith(section_prefix):
+                env_var = env_var.lstrip(section_prefix)
+                ret_dict[env_var] = self.__getattr__(env_var)()
+        return ret_dict
+
 
 class Config:
     """Base Config item"""
@@ -162,6 +175,9 @@ class Config:
 
     def __getattr__(self, name):
         return ConfigSection(name, None)
+
+    def to_dict(self):
+        pass
 
 
 class AutoConfig(Config):

--- a/youconfigme/youconfigme.py
+++ b/youconfigme/youconfigme.py
@@ -119,6 +119,8 @@ class ConfigSection:
         return ConfigAttribute(self.name, None, None)(default=default, cast=cast)
 
     def to_dict(self):
+        """Returns a dictionary with all the key:value pairs from the initial mapping,
+        neglecting environment variables not present there"""
         if self.items == {}:
             raise ConfigItemNotFound
         ret_dict = {k: self.__getattr__(k)() for k in self.items.keys()}
@@ -181,6 +183,8 @@ class Config:
         return ConfigSection(name, None)
 
     def to_dict(self):
+        """Returns a dictionary with all the key:value pairs from the initial mapping,
+        neglecting environment variables not present there"""
         ret_dict = {}
         for section in self.config_sections:
             ret_dict[section] = self.__getattribute__(section).to_dict()


### PR DESCRIPTION
Adds a `to_dict` method for `Config` that returns a dict from the configuration on the initial mapping. Neglects environment variables.